### PR TITLE
[Sync] Update project files from source repository (6b279b0)

### DIFF
--- a/.github/actions/setup-goreleaser/action.yml
+++ b/.github/actions/setup-goreleaser/action.yml
@@ -105,7 +105,7 @@ runs:
     # --------------------------------------------------------------------
     - name: ✅ Install GoReleaser (cache miss)
       if: steps.check-existing.outputs.exists != 'true' && steps.goreleaser-cache.outputs.cache-hit != 'true'
-      uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
+      uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
       with:
         distribution: goreleaser
         version: ${{ inputs.goreleaser-version }}

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.20.15
+MAGE_X_VERSION=v1.20.16
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -62,7 +62,7 @@ MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea
 MAGE_X_GITLEAKS_VERSION=8.30.1
 MAGE_X_GOFUMPT_VERSION=v0.9.2
 MAGE_X_GOLANGCI_LINT_VERSION=v2.11.4
-MAGE_X_GORELEASER_VERSION=v2.15.3
+MAGE_X_GORELEASER_VERSION=v2.15.4
 MAGE_X_GOVULNCHECK_VERSION=v1.1.4
 MAGE_X_GO_SECONDARY_VERSION=1.24.x
 MAGE_X_GO_VERSION=1.24.x
@@ -72,7 +72,7 @@ MAGE_X_STATICCHECK_VERSION=2026.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
 MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260409210113-8e83ce0f7b1c
-MAGE_X_MAGE_VERSION=v1.17.1
+MAGE_X_MAGE_VERSION=v1.17.2
 
 # ================================================================================================
 # 📝 RUNTIME VARIABLES (set by setup-goreleaser action)

--- a/.github/workflows/fortress-security-scans.yml
+++ b/.github/workflows/fortress-security-scans.yml
@@ -160,6 +160,13 @@ jobs:
           if [[ $NANCY_EXIT_CODE -eq 0 ]]; then
             echo "nancy-status=success" >> $GITHUB_OUTPUT
             echo "✅ Nancy scan completed - no vulnerabilities found"
+          elif grep -qi "rate limited by OSS Index" nancy-output.log; then
+            # OSS Index rate-limited the scan; treat as inconclusive, NOT as a CI failure.
+            # Add OSSI_USERNAME and OSSI_TOKEN secrets to authenticate and lift the limit.
+            echo "nancy-status=rate-limited" >> $GITHUB_OUTPUT
+            echo "⚠️  Nancy scan inconclusive - OSS Index rate-limited the request (not failing CI)."
+            echo "    Configure OSSI_USERNAME and OSSI_TOKEN secrets to authenticate and lift the limit."
+            echo "    Register at https://ossindex.sonatype.org/user/register"
           else
             echo "nancy-status=failure" >> $GITHUB_OUTPUT
             echo "❌ Nancy scan completed - vulnerabilities detected (exit code: $NANCY_EXIT_CODE)"
@@ -168,10 +175,18 @@ jobs:
       # --------------------------------------------------------------------
       # Create GitHub Annotations for failures
       # --------------------------------------------------------------------
-      - name: 📋 Create GitHub Annotations
+      - name: 📋 Create GitHub Annotations (vulnerabilities)
         if: always() && steps.run-nancy.outputs.nancy-status == 'failure'
         run: |
           echo "::error title=Nancy Security Scan Failed::Vulnerabilities detected in Go dependencies - see job summary for details"
+
+      # --------------------------------------------------------------------
+      # Create GitHub Annotations for rate-limited scans (warning, not error)
+      # --------------------------------------------------------------------
+      - name: 📋 Create GitHub Annotations (rate-limited)
+        if: always() && steps.run-nancy.outputs.nancy-status == 'rate-limited'
+        run: |
+          echo "::warning title=Nancy Rate Limited::OSS Index rate-limited the scan; results inconclusive. Add OSSI_USERNAME and OSSI_TOKEN secrets to authenticate and lift the limit."
 
       # --------------------------------------------------------------------
       # Summary of Nancy results
@@ -192,6 +207,8 @@ jobs:
 
           if [[ "$NANCY_STATUS" == "success" ]]; then
             echo "| **Result** | ✅ No vulnerabilities found |" >> $GITHUB_STEP_SUMMARY
+          elif [[ "$NANCY_STATUS" == "rate-limited" ]]; then
+            echo "| **Result** | ⚠️ Rate limited by OSS Index — scan inconclusive (CI not failed) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| **Result** | ❌ Vulnerabilities detected |" >> $GITHUB_STEP_SUMMARY
           fi
@@ -201,8 +218,33 @@ jobs:
           echo "The following vulnerabilities were excluded from the scan:" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.NANCY_EXCLUDES }}" >> $GITHUB_STEP_SUMMARY
 
-          # Show failure details if applicable
-          if [[ "$NANCY_STATUS" != "success" ]] && [[ -f nancy-output.log ]]; then
+          # Rate-limited: explain clearly that CI was NOT failed and how to remediate
+          if [[ "$NANCY_STATUS" == "rate-limited" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ OSS Index Rate Limit" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Sonatype's OSS Index rate-limited this request before Nancy could complete the scan." >> $GITHUB_STEP_SUMMARY
+            echo "**This is not a vulnerability detection** and CI has **not** been failed for this run." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**To remediate (recommended):**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "1. Register a free account at <https://ossindex.sonatype.org/user/register>." >> $GITHUB_STEP_SUMMARY
+            echo "2. Retrieve your username (email) and API token from <https://ossindex.sonatype.org/user/settings>." >> $GITHUB_STEP_SUMMARY
+            echo "3. Add them as repository secrets named \`OSSI_USERNAME\` and \`OSSI_TOKEN\`." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Authenticated requests have a substantially higher rate limit and avoid this state." >> $GITHUB_STEP_SUMMARY
+            if [[ -f nancy-output.log ]]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "<details>" >> $GITHUB_STEP_SUMMARY
+              echo "<summary>Click to expand Nancy output</summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              head -50 nancy-output.log >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+            fi
+          # Real vulnerability failure: keep existing details section
+          elif [[ "$NANCY_STATUS" == "failure" ]] && [[ -f nancy-output.log ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### 🚨 Vulnerability Details" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -252,6 +294,12 @@ jobs:
 
       # --------------------------------------------------------------------
       # Fail job if vulnerabilities found
+      #
+      # Only fires when nancy-status == 'failure' (real vulnerabilities).
+      # The 'rate-limited' status is intentionally excluded: an OSS Index rate
+      # limit produces an inconclusive scan, not a vulnerability finding, and
+      # must not red-X CI. See the run-nancy step above for the rate-limit
+      # detection logic.
       # --------------------------------------------------------------------
       - name: 🚨 Fail job if vulnerabilities found
         if: always() && steps.run-nancy.outputs.nancy-status == 'failure'

--- a/.github/workflows/fortress.yml
+++ b/.github/workflows/fortress.yml
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------------
 #  🏰 GoFortress - Enterprise-grade CI/CD fortress for Go applications
 #
-#  Version: 1.7.2 | Released: 2026-03-09
+#  Version: 1.7.3 | Released: 2026-04-28
 #
 #  Built Strong. Tested Harder.
 #


### PR DESCRIPTION
## What Changed

* Updated goreleaser-action from `e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c` (v7.1.0) to `1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8` (v7.2.1) in `.github/actions/setup-goreleaser/action.yml`
* Bumped MAGE_X_VERSION from `v1.20.15` to `v1.20.16` in `.github/env/10-mage-x.env`
* Updated MAGE_X_GORELEASER_VERSION from `v2.15.3` to `v2.15.4` in `.github/env/10-mage-x.env`
* Updated MAGE_X_MAGE_VERSION from `v1.17.1` to `v1.17.2` in `.github/env/10-mage-x.env`
* Added rate-limiting detection and handling for Nancy security scans in `.github/workflows/fortress-security-scans.yml` - when OSS Index rate-limits the scan, it now sets status to `rate-limited` and logs a warning instead of failing CI
* Added informational message directing users to register at `https://ossindex.sonatype.org/user/register` and configure `OSSI_USERNAME` and `OSSI_TOKEN` secrets to authenticate and lift rate limits

## Why It Was Necessary

* Keeping dependency scanning tools and build automation (goreleaser, mage) up to date ensures access to latest bug fixes and security patches
* Nancy scans were failing CI pipelines due to OSS Index rate limiting, which is an infrastructure constraint rather than an actual security issue that should block builds
* Providing clear guidance on authentication helps users resolve rate-limiting issues without requiring intervention from maintainers

## Testing Performed

* Verify goreleaser-action v7.2.1 successfully installs and executes goreleaser v2.15.4 in CI workflows
* Confirm mage-x v1.20.16 integrates properly with updated mage v1.17.2
* Test that Nancy scans correctly detect rate-limiting messages in output and set appropriate status without failing the CI pipeline
* Validate that informational messages about OSS Index authentication are displayed when rate-limiting occurs

## Impact / Risk

* **Breaking Change**: None - all changes are backward compatible dependency updates and improved error handling
* **Risk**: Low - version updates are incremental and the Nancy rate-limiting change makes CI more resilient rather than introducing new failure modes
* **Performance**: Nancy scan failures due to rate-limiting will no longer block CI pipelines unnecessarily, improving developer experience

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 6b279b0850fcea35feb4582ceb63e981d68be875
  target_repo: mrz1836/go-api-router
  sync_commit: a90c9aebe54765b51daa8a4acf32a9b5a0d92cc1
  sync_time: 2026-04-29T07:38:05-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 460
  - src: .github/actions
    dest: .github/actions
    files_synced: 1
    files_examined: 18
    files_excluded: 0
    processing_time_ms: 1569
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 472
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 663
  - src: .github/scripts
    dest: .github/scripts
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 484
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1375
  - src: .github/workflows
    dest: .github/workflows
    files_synced: 2
    files_examined: 26
    files_excluded: 0
    processing_time_ms: 2912
  - src: .vscode
    dest: .vscode
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 328
performance:
  total_files: 101
-->
